### PR TITLE
Changing check for directory existing to false

### DIFF
--- a/tg/cli.py
+++ b/tg/cli.py
@@ -21,7 +21,7 @@ def checkmark(value):
     '--home', default=click.get_app_dir('tg'), envvar='TG_HOME',
     type=click.Path(
         file_okay=False, resolve_path=True,
-        exists=True, readable=True, writable=True),
+        exists=False, readable=True, writable=True),
     help="Path to a directory that tg will store obj in")
 @click.version_option(__version__)
 @click.pass_context


### PR DESCRIPTION
Creating a new tag will create a new directory, but the option would
error out due to the directory not existing before being able to
create it.

```
(venv)foo@bar  ~/Documents/projects/tg/tg   git:master*
 >>  tg add formulary ~/Documents/diss/formulary
Usage: tg [OPTIONS] COMMAND [ARGS]...

Error: Invalid value for "--home": Directory "/Users/foo/Library/Application Support/tg" does not exist.
```